### PR TITLE
refactor docker images to allow base images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ env:
   - TEST_IMAGE=ubuntu-14.04
   - TEST_IMAGE=ubuntu-16.04
   - TEST_IMAGE=ubuntu-18.04
+  - TEST_IMAGE=base-ubuntu-14.04
+  - TEST_IMAGE=base-ubuntu-16.04
+  - TEST_IMAGE=base-ubuntu-18.04
+  - TEST_IMAGE=base-centos-7
 before_install:
 - "./ci/prepare.sh"
 - |

--- a/ci/deploy_docker.py
+++ b/ci/deploy_docker.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import re
 import requests
 import subprocess
 import sys
@@ -42,9 +43,24 @@ def main():
         return 1
 
     print("Building", name)
+    # Construct the arguments for the build command.
+    docker_build_args = [
+        '-t', name,
+        '-f', '%s/Dockerfile' % docker_dir,
+        '--build-arg', 'PYREX_BASE=%s' % re.sub('^base-', '', image)
+    ]
+    # If we are a base image then we need to build the base image as a name.
+    if image.startswith('base-'):
+        # If we are building a 'base-*' image then we should build the pyrex-base target.
+        docker_build_args.extend([
+            '--target', 'pyrex-base'
+        ])
+
+    # Add the build context directory to our arguments.
+    docker_build_args.extend(['--', docker_dir])
+
     try:
-        subprocess.check_call(['docker', 'build', '-t', name, '-f', '%s/Dockerfile' % docker_dir,
-                               '--build-arg', 'PYREX_BASE=%s' % image, '--', docker_dir])
+        subprocess.check_call(['docker', 'build'] + docker_build_args)
     except subprocess.CalledProcessError as e:
         print("Building failed!")
         return 1

--- a/ci/test.py
+++ b/ci/test.py
@@ -416,7 +416,10 @@ class TestImage(PyrexTest):
         self.assertPyrexContainerCommand('tini --version')
 
     def test_icecc(self):
-        self.assertPyrexContainerCommand('icecc --version')
+        if self.test_image.startswith('base-'):
+            self.skipTest('icecc is not installed on base images.')
+        else:
+            self.assertPyrexContainerCommand('icecc --version')
 
     def test_guest_image(self):
         # This test makes sure that the image being tested is the image we
@@ -424,11 +427,24 @@ class TestImage(PyrexTest):
         if not self.test_image:
             self.skipTest("%s not defined" % TEST_IMAGE_ENV_VAR)
 
+        # Get the test image name (strip out the base-) identifier.
+        image_name = re.sub('^base-', '', self.test_image)
+
+        expected_dist_id = image_name.split('-', 1)[0]
+        expected_release_str = image_name.split('-', 1)[1]
+
+        # Capture the LSB release information.
         dist_id_str = self.assertPyrexContainerCommand('lsb_release -i', quiet_init=True, capture=True).decode('utf-8').rstrip()
         release_str = self.assertPyrexContainerCommand('lsb_release -r', quiet_init=True, capture=True).decode('utf-8').rstrip()
 
-        self.assertRegex(dist_id_str.lower(), r'^distributor id:\s+' + re.escape(self.test_image.split('-', 1)[0]))
-        self.assertRegex(release_str.lower(), r'^release:\s+' + re.escape(self.test_image.split('-', 1)[1]))
+        self.assertRegex(dist_id_str.lower(), r'^distributor id:\s+' + re.escape(expected_dist_id))
+        self.assertRegex(
+            release_str.lower(),
+            # If we are using the centos 7 image, we need to match the
+            # major[.minor[.micro]] version pattern. we only care if the major
+            # version is 7.
+            r'^release:\s+' + re.escape(expected_release_str) + r'\.[0-9]+\.[0-9]+'if expected_dist_id == 'centos' else r''
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,7 +114,6 @@ RUN mkdir -p /usr/src/tini && \
     make && \
     make install DESTDIR=/dist/tini && \
     mv /dist/tini/usr/local/bin/tini-static /dist/tini/usr/local/bin/tini
-
 #
 # Ubuntu 14.04 base
 #
@@ -122,12 +121,124 @@ FROM ${MY_REGISTRY}ubuntu:trusty as ubuntu-14.04
 LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 
 # Install software required to add ppa's
-RUN apt-get -y update && apt-get -y install \
+RUN set -x && export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
     python-software-properties \
-    software-properties-common
-
+    sudo \
+    locales \
+    python \
+    python3 \
+    software-properties-common && \
 # Add a non-ancient version of git
-RUN add-apt-repository -y ppa:git-core/ppa
+    add-apt-repository -y ppa:git-core/ppa && \
+# Clean up apt-cache
+    rm -rf /var/lib/apt/lists/* &&\
+# generate utf8 locale
+    locale-gen en_US.UTF-8
+
+# Copy prebuilt items
+COPY --from=prebuilt-setpriv /dist/setpriv /
+COPY --from=prebuilt-tini /dist/tini /
+
+#
+# Ubuntu 16.04 Base
+
+FROM ${MY_REGISTRY}ubuntu:xenial as ubuntu-16.04
+LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
+
+# Install software required to add ppa's
+RUN set -x && export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
+    python-software-properties \
+    locales \
+    sudo \
+    python3 \
+    software-properties-common && \
+# Add a non-ancient version of git to the repo so we can install it in downstream images.
+    add-apt-repository -y ppa:git-core/ppa && \
+# Clean up apt-cache
+    rm -rf /var/lib/apt/lists/* &&\
+# generate utf8 locale
+    locale-gen en_US.UTF-8
+
+# Copy prebuilt items
+COPY --from=prebuilt-setpriv /dist/setpriv /
+COPY --from=prebuilt-tini /dist/tini /
+
+#
+# Ubuntu 18.04 Base
+#
+FROM ${MY_REGISTRY}ubuntu:bionic as ubuntu-18.04
+LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
+
+RUN set -x && export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
+    python \
+    python3 \
+# Tools used by Pyrex
+    lsb-release \
+    setpriv \
+    sudo \
+    locales &&\
+    rm -rf /var/lib/apt/lists/* && \
+# generate utf8 locale
+    locale-gen en_US.UTF-8
+
+# Copy prebuilt items
+COPY --from=prebuilt-tini /dist/tini /
+
+#
+# Centos 7
+#
+FROM ${MY_REGISTRY}centos:7 as centos-7
+LABEL maintainer="James Harris <james.harris@garmin.com>"
+RUN set -x && \
+      #Install default components
+      yum install -y yum-utils \
+          which \
+          sudo \
+          redhat-lsb-core \
+          &&\
+      yum install -y https://centos7.iuscommunity.org/ius-release.rpm &&\
+      yum install -y python36u &&\
+      yum clean all &&\
+      ln -s /usr/bin/python3.6 /usr/bin/python3 &&\
+      localedef -c -f UTF-8 -i en_US en_US.UTF-8
+
+# Copy prebuilt items
+COPY --from=prebuilt-setpriv /dist/setpriv /
+COPY --from=prebuilt-tini /dist/tini /
+
+#
+# Target image
+#
+FROM ${PYREX_BASE} as pyrex-base
+
+# Set Locales
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+# Add startup scripts
+COPY ./startup.sh /usr/libexec/tini/startup.sh
+COPY ./entry.py /usr/libexec/tini/entry.py
+COPY ./cleanup.py /usr/libexec/tini/cleanup.py
+RUN chmod +x /usr/libexec/tini/cleanup.py \
+    /usr/libexec/tini/entry.py \
+    /usr/libexec/tini/startup.sh
+
+# Precompile python files for improved startup time
+RUN python3 -m py_compile /usr/libexec/tini/*.py
+
+# Use tini as the init process and instruct it to invoke the cleanup script
+# once the primary command dies
+ENTRYPOINT ["/usr/local/bin/tini", "-P", "/usr/libexec/tini/cleanup.py", "{}", ";", "--", "/usr/libexec/tini/entry.py", "/usr/libexec/tini/startup.sh"]
+
+# The startup script is expected to chain along to some other
+# command. By default, we'll use an interactive shell.
+CMD ["/bin/bash"]
+
+#
+# Ubuntu 14.04 Yocto Base
+#
+FROM ubuntu-14.04 as ubuntu-14.04-yocto
+LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
 # Poky 2.0 build dependencies
@@ -197,22 +308,12 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y ins
 
 # Copy prebuilt items
 COPY --from=prebuilt-icecream /dist/icecream /
-COPY --from=prebuilt-setpriv /dist/setpriv /
-COPY --from=prebuilt-tini /dist/tini /
 
 #
-# Ubuntu 16.04 Base
+# Ubuntu 16.04 Yocto Base
 #
-FROM ${MY_REGISTRY}ubuntu:xenial as ubuntu-16.04
+FROM ubuntu-16.04 as ubuntu-16.04-yocto
 LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
-
-# Install software required to add ppa's
-RUN apt-get -y update && apt-get -y install \
-    python-software-properties \
-    software-properties-common
-
-# Add a non-ancient version of git
-RUN add-apt-repository -y ppa:git-core/ppa
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
 # Poky 2.7 build dependencies
@@ -277,13 +378,11 @@ RUN python3 -m pip install jinja2 iterfzf
 
 # Copy prebuilt items
 COPY --from=prebuilt-icecream /dist/icecream /
-COPY --from=prebuilt-setpriv /dist/setpriv /
-COPY --from=prebuilt-tini /dist/tini /
 
 #
 # Ubuntu 18.04 Base
 #
-FROM ${MY_REGISTRY}ubuntu:bionic as ubuntu-18.04
+FROM ubuntu-18.04 as ubuntu-18.04-yocto
 LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
@@ -336,9 +435,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y ins
     g++-multilib \
 # Screen to enable devshell
     screen \
-# Tools used by Pyrex
-    lsb-release \
-    setpriv \
 # Base OS stuff that reasonable workstations have, but which the Docker
 # registry image doesn't
     tzdata \
@@ -349,12 +445,11 @@ RUN python3 -m pip install iterfzf
 
 # Copy prebuilt items
 COPY --from=prebuilt-icecream /dist/icecream /
-COPY --from=prebuilt-tini /dist/tini /
 
-# 
+#
 # Target image
 #
-FROM ${PYREX_BASE}
+FROM ${PYREX_BASE}-yocto
 
 # Setup Icecream distributed compiling client. The client tries several IPC
 # mechanisms to find the daemon, including connecting to a localhost TCP


### PR DESCRIPTION
Other projects could take advantage of having a stripped down image that
supports the current user. It provides the following new images:

  * base-ubuntu-14.04
  * base-ubuntu-16.04
  * base-ubuntu-18.04
  * base-centos-7  (not supported by full pyrex)

These images only install the bare minimum requirements to run tini and
eventually provide an updated version of git if such a version is
required upstream.

Centos does the additional work to install python3 (required by pyrex's
startup/shutdown scripts).